### PR TITLE
Update Loblaw Banners/Brands:

### DIFF
--- a/Great-Canadian-Grocery-Chart.html
+++ b/Great-Canadian-Grocery-Chart.html
@@ -32,7 +32,7 @@
             <li>Loblaws</li>
             <li>Zehrs</li>
             <li>Your Independent Grocer</li>
-            <li>valu-mart</li>
+            <li>valu-mart (To be Discontinued)</li>
             <li>Provigo</li>
             <li>Atlantic Superstore</li>
             <li>Real Canadian Superstore</li>
@@ -235,11 +235,12 @@
       </tr>
 <!--**********Liquor Store Banners**********-->
       <tr>
-        <td>Liquor Store Banners</td>
+        <td>Liquor Store / Recreational Cannabis Store Banners</td>
         <td>
           <!--Loblaw-->
           <ul>
             <li>Real Canadian Liquorstore</li>
+            <li>C-Shop Cannabis</li>
           </ul>
         </td>
         <td>
@@ -371,12 +372,13 @@
             <li>PC Insurance</li>
             <li>PC Travel</li>
             <li>PC Telecom (PC Mobile)</li>
-            <li>PC Gift Card/The Gift of Choice</li>
+            <li>PC Gift Card/The Gift of Choice (Partnership)</li>
             <li>PC Cooking School</li>
             <li>PC Health</li>
             <li>MobileSHOP (PC Telecom)</li>
             <li>Beauty Boutique</li>
             <li>The Health Clinic/Primacy Medical Clinic (Partnership)</li>
+            <li>Specialty Health Network</li>
             <li>PhotoLab</li>
             <li>Lifemark Health Group</li>
           </ul>
@@ -428,6 +430,7 @@
             <li>PC Black Label Collection</li>
             <li>PC Free From</li>
             <li>PC Nutrition First</li>
+            <li>PC GREEN/Planet First</li>
             <li>No Name</li>
             <li>Real Canadian Spring Water</li>
             <li>Farmer's Market</li>
@@ -435,6 +438,7 @@
             <li>Sunspun</li>
             <li>Ziggy's</li>
             <li>T&T Brand (Store Brand)</li>
+            <li>Pane Fresco (Bakery & HMR Products)</li>
           </ul>
         </td>
         <td>
@@ -624,6 +628,6 @@
     <p>^Mobile phone sales provided by Glentel Inc. (Ownership: 50% BCE, 50% Rogers Communications). [<a href="https://en.wikipedia.org/wiki/Glentel">Source</a>]</p>
   </div>
   <div>
-    <i>Last Updated: 2023-03-09</i> <a href="https://jacobnelson.ca">jacobnelson.ca</a>
+    <i>Last Updated: 2024-01-17</i> <a href="https://jacobnelson.ca">jacobnelson.ca</a>
   </div>
 </html>


### PR DESCRIPTION
- Add C-Stop Cannabis Retailer
- Add Specialty Health Network
- Add PC GREEN/Planet First
- Add Pane Fresco

- Update PC Gift Card/The Gift of Choice to indicate that it is a partnership
- Update valu-mart to indicate that the banner is being phased out