### PR TITLE
Moved "Arz Fine Foods" to "Major Independents"

### DIFF
--- a/Great-Canadian-Grocery-Chart.html
+++ b/Great-Canadian-Grocery-Chart.html
@@ -51,9 +51,6 @@
             <li>Independent CityMarket</li>
             <li>L'intermarche***</li>
             <li>AXEP***</li>
-            <li>
-              <a href="https://financialpost.com/investing/loblaw-scoops-up-arz-fine-foods-with-eye-on-growing-demand-for-middle-eastern-cuisine" target="_blank">Arz Fine Foods</a>
-            </li>
           </ul>
         </td>
         <td>
@@ -142,6 +139,16 @@
                 <li>RiteWay Food Markets</li>
                 <li>Solo Market</li>
                 <li>Valu Lots</li>
+              </ul>
+            </li>
+            <li>
+              Arz Fine Foods
+              <ul>
+                <li>
+                    <a href="https://financialpost.com/investing/loblaw-scoops-up-arz-fine-foods-with-eye-on-growing-demand-for-middle-eastern-cuisine" target="_blank">
+                      Former Loblaw Asset
+                    </a>
+                </li>
               </ul>
             </li>
           </ul>
@@ -623,7 +630,6 @@
             <li>Ziggy's</li>
             <li>T&T Brand (Store Brand)</li>
             <li>Pane Fresco (Bakery &#38; HMR Products)</li>
-            <li>Arz Fine Foods (Store Brand)</li>
           </ul>
         </td>
         <td>
@@ -686,6 +692,14 @@
               <a href="https://www.gianttiger.com/pages/about-us" target="_blank">Giant Tiger</a>
               <ul>
                 <li>Giant Value</li>
+              </ul>
+            </li>
+            <li>
+              Arz Fine Foods
+              <ul>
+                <li>
+                  Arz Fine Foods (Store Brand)
+                </li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
"Arz Fine Foods" was moved to "Major Independents" as Loblaw appears to have divested the company back to the founders sometime in 2018.

Also...
- Added a sub bullet to "Arz Fine Foods" which indicates that it was a former Loblaw asset.
- Moved "Arz Fine Foods (Store Brand)" to "Major Independents" column.