### PR TITLE
Updated Loblaw and Metro on the chart.

### DIFF
--- a/Great-Canadian-Grocery-Chart.html
+++ b/Great-Canadian-Grocery-Chart.html
@@ -275,9 +275,7 @@
         <td>
           <!--Metro Inc.-->
           <ul>
-            <li>AirMiles (Ontario)</li>
-            <li>Thunder Bucks (Thunder Bay)</li>
-            <li>Metro et Moi</li>
+            <li>Moi Rewards</li>
           </ul>
         </td>
         <td>
@@ -516,7 +514,7 @@
             <li>PC Travel (<a href="https://creditcardgenius.ca/blog/pc-travel" target="_blank">Discontinued 2023-07-15</a>)</li>
             <li>PC Mobile (PC Telecom)</li>
             <li>No Name Mobile (Division of PC Mobile)</li>
-            <li>MobileSHOP (PC Mobile)</li>
+            <li>MobileSHOP (PC Mobile)^</li>
             <li>PC Gift Card/The Gift of Choice (Partnership)</li>
             <li>PC Cooking School</li>
             <li>PC Health</li>
@@ -630,6 +628,17 @@
             <li>Ziggy's</li>
             <li>T&T Brand (Store Brand)</li>
             <li>Pane Fresco (Bakery &#38; HMR Products)</li>
+            <li>From Our Chefs (HMR Products)</li>
+            <li>Old Mill</li>
+            <li>Nuttin' But Spreads</li>
+            <li>Harvest Peak</li>
+            <li>SeaQuest</li>
+            <li>Pride of Arabia</li>
+            <li>Foremost Dairies</li>
+            <li>Rooster Brand</li>
+            <li>Sufra</li>
+            <li>Suraj</li>
+            <li>Azami</li>
           </ul>
         </td>
         <td>
@@ -881,6 +890,6 @@
     <p>^Mobile phone sales provided by Glentel Inc. (Ownership: 50% BCE, 50% Rogers Communications). [<a href="https://en.wikipedia.org/wiki/Glentel" target="_blank">Source</a>]</p>
   </div>
   <div>
-    <i>Last Updated: 2024-04-15</i> <a href="https://jacobnelson.ca" target="_blank">jacobnelson.ca</a>
+    <i>Last Updated: 2024-07-29</i> <a href="https://jacobnelson.ca" target="_blank">jacobnelson.ca</a>
   </div>
 </html>


### PR DESCRIPTION
- Added Loblaw private label brands indicated here: https://www.reddit.com/r/loblawsisoutofcontrol/comments/1ant3p8/a_broad_overview_of_loblaws_private_label_brands/
- Added indicator to MobileSHOP to show that this division is supplied by Glentel Inc.
- Removed AirMiles and Thunder Bucks from Metro's loyalty programmes as both were discontinued as of July 2024.
- Renamed Metro's loyalty programme "Metro et Moi" to "Moi Rewards" to reflect new programme name.